### PR TITLE
[WIP]: add stratumv2 listening port configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2057,6 +2057,7 @@ echo "  debug enabled   = $enable_debug"
 echo "  gprof enabled   = $enable_gprof"
 echo "  werror          = $enable_werror"
 echo "  LTO             = $enable_lto"
+echo "  with stratumv2 template provider = $add_template_provider"
 echo
 echo "  target os       = $host_os"
 echo "  build os        = $build_os"

--- a/configure.ac
+++ b/configure.ac
@@ -358,7 +358,7 @@ AC_ARG_ENABLE([template-provider],
     [AS_HELP_STRING([--enable-template-provider],[compile template provider (default is no, requires rustc)])],
     [AS_IF([test ${RUSTC} = yes],
             [
-                AC_DEFINE([ENABLE_TMEPLATE_PROVIDER],[1],[Define if TP should be compiled in])
+                AC_DEFINE([ENABLE_TEMPLATE_PROVIDER],[1],[Define if TP should be compiled in])
                 LDFLAGS="$LDFLAGS -lpthread -ldl"
                 add_template_provider=$enableval
             ],
@@ -1899,7 +1899,7 @@ AM_CONDITIONAL([USE_ASM], [test "$use_asm" = "yes"])
 AM_CONDITIONAL([WORDS_BIGENDIAN], [test "$ac_cv_c_bigendian" = "yes"])
 AM_CONDITIONAL([USE_NATPMP], [test "$use_natpmp" = "yes"])
 AM_CONDITIONAL([USE_UPNP], [test "$use_upnp" = "yes"])
-AM_CONDITIONAL([ENABLE_TMEPLATE_PROVIDER],[test "$add_template_provider" = "yes"])
+AM_CONDITIONAL([ENABLE_TEMPLATE_PROVIDER],[test "$add_template_provider" = "yes"])
 
 dnl for minisketch
 AM_CONDITIONAL([ENABLE_CLMUL], [test "$enable_clmul" = "yes"])
@@ -1979,7 +1979,7 @@ AC_SUBST(HAVE_MM_PREFETCH)
 AC_SUBST(HAVE_STRONG_GETAUXVAL)
 AC_SUBST(ANDROID_ARCH)
 AC_SUBST(HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR)
-AC_SUBST(ENABLE_TMEPLATE_PROVIDER)
+AC_SUBST(ENABLE_TEMPLATE_PROVIDER)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile share/setup.nsi share/qt/Info.plist test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
 AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1072,6 +1072,6 @@ include Makefile.qttest.include
 endif
 
 include Makefile.univalue.include
-if ENABLE_TMEPLATE_PROVIDER
+if ENABLE_TEMPLATE_PROVIDER
 include Makefile.template_provider.include
 endif

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -254,7 +254,7 @@ static bool AppInit(NodeContext& node, int argc, char* argv[])
 }
 
 
-#ifdef ENABLE_TMEPLATE_PROVIDER
+#ifdef ENABLE_TEMPLATE_PROVIDER
     #include <rusty/protocols/v2/sv2-ffi/sv2.h>
     // It uses the sv2_ffi library to build a correct Sv2 message and an incorrect one.
     // Then try to encode them, it print ok if the ecoding is possible it print err if not.
@@ -314,7 +314,7 @@ int main(int argc, char* argv[])
     util::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
-#ifdef ENABLE_TMEPLATE_PROVIDER
+#ifdef ENABLE_TEMPLATE_PROVIDER
     test_template_provider();
 #else
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -594,6 +594,10 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-sandbox=<mode>", "Use the experimental syscall sandbox in the specified mode (-sandbox=log-and-abort or -sandbox=abort). Allow only expected syscalls to be used by bitcoind. Note that this is an experimental new feature that may cause bitcoind to exit or crash unexpectedly: use with caution. In the \"log-and-abort\" mode the invocation of an unexpected syscall results in a debug handler being invoked which will log the incident and terminate the program (without executing the unexpected syscall). In the \"abort\" mode the invocation of an unexpected syscall results in the entire process being killed immediately by the kernel without executing the unexpected syscall.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif // USE_SYSCALL_SANDBOX
 
+#if ENABLE_TEMPLATE_PROVIDER
+    argsman.AddArg("-stratumv2=<port>", "Listen for stratumv2 connections on <port>. Bitcoind will act as a Template Provider. (default: 8442)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+#endif
+
     // Add the hidden options
     argsman.AddHiddenArgs(hidden_args);
 }


### PR DESCRIPTION
TODO - Housekeeping:
* Please review from: https://github.com/stratum-mining/bitcoin/commit/962f4b323b33669d1f411495bc807b74cb7b3338
* This is currently branched from [2022.05.17-fix-template-provider-compile-options](https://github.com/stratum-mining/bitcoin/pull/21), please review and merge that PR before attempting to merge this one.
* I will rebase this PR on top of [add_sv2](https://github.com/stratum-mining/bitcoin/tree/add_sv2) if the previously mentioned PR above is merged into [add_sv2](https://github.com/stratum-mining/bitcoin/tree/add_sv2). 



TODO - Discussion:

* The below are points that should be discussed/reviewed internally before making more progress on this specific topic:
    * [ ] I set a default port of `8442` for the listening port of the Template Provider on all environments, this is completely arbitrary. Is there a better port to use or one suggested by the specs?
    * [ ] Should we set default ports per Bitcoin environment? e.g. `8442 : mainnet`, `8444 : devnet`, `8445 : regtest` etc... 
        * Example: [Different RPC for different environments](https://github.com/bitcoin/bitcoin/blob/master/src/init.cpp#L576)
    * [ ] Currently assumes the server will bind to `0.0.0.0`, should we allow the user to also specify an address they can bind the to?