### PR TITLE
Remove rust example code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2057,6 +2057,7 @@ echo "  debug enabled   = $enable_debug"
 echo "  gprof enabled   = $enable_gprof"
 echo "  werror          = $enable_werror"
 echo "  LTO             = $enable_lto"
+echo "  with stratumv2 template provider = $add_template_provider"
 echo
 echo "  target os       = $host_os"
 echo "  build os        = $build_os"

--- a/configure.ac
+++ b/configure.ac
@@ -358,7 +358,7 @@ AC_ARG_ENABLE([template-provider],
     [AS_HELP_STRING([--enable-template-provider],[compile template provider (default is no, requires rustc)])],
     [AS_IF([test ${RUSTC} = yes],
             [
-                AC_DEFINE([ENABLE_TMEPLATE_PROVIDER],[1],[Define if TP should be compiled in])
+                AC_DEFINE([ENABLE_TEMPLATE_PROVIDER],[1],[Define if TP should be compiled in])
                 LDFLAGS="$LDFLAGS -lpthread -ldl"
                 add_template_provider=$enableval
             ],
@@ -1899,7 +1899,7 @@ AM_CONDITIONAL([USE_ASM], [test "$use_asm" = "yes"])
 AM_CONDITIONAL([WORDS_BIGENDIAN], [test "$ac_cv_c_bigendian" = "yes"])
 AM_CONDITIONAL([USE_NATPMP], [test "$use_natpmp" = "yes"])
 AM_CONDITIONAL([USE_UPNP], [test "$use_upnp" = "yes"])
-AM_CONDITIONAL([ENABLE_TMEPLATE_PROVIDER],[test "$add_template_provider" = "yes"])
+AM_CONDITIONAL([ENABLE_TEMPLATE_PROVIDER],[test "$add_template_provider" = "yes"])
 
 dnl for minisketch
 AM_CONDITIONAL([ENABLE_CLMUL], [test "$enable_clmul" = "yes"])
@@ -1979,7 +1979,7 @@ AC_SUBST(HAVE_MM_PREFETCH)
 AC_SUBST(HAVE_STRONG_GETAUXVAL)
 AC_SUBST(ANDROID_ARCH)
 AC_SUBST(HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR)
-AC_SUBST(ENABLE_TMEPLATE_PROVIDER)
+AC_SUBST(ENABLE_TEMPLATE_PROVIDER)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile share/setup.nsi share/qt/Info.plist test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
 AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1072,6 +1072,6 @@ include Makefile.qttest.include
 endif
 
 include Makefile.univalue.include
-if ENABLE_TMEPLATE_PROVIDER
+if ENABLE_TEMPLATE_PROVIDER
 include Makefile.template_provider.include
 endif

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -254,7 +254,7 @@ static bool AppInit(NodeContext& node, int argc, char* argv[])
 }
 
 
-#ifdef ENABLE_TMEPLATE_PROVIDER
+#ifdef ENABLE_TEMPLATE_PROVIDER
     #include <rusty/protocols/v2/sv2-ffi/sv2.h>
     // It uses the sv2_ffi library to build a correct Sv2 message and an incorrect one.
     // Then try to encode them, it print ok if the ecoding is possible it print err if not.
@@ -314,7 +314,7 @@ int main(int argc, char* argv[])
     util::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
-#ifdef ENABLE_TMEPLATE_PROVIDER
+#ifdef ENABLE_TEMPLATE_PROVIDER
     test_template_provider();
 #else
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -253,70 +253,12 @@ static bool AppInit(NodeContext& node, int argc, char* argv[])
     return fRet;
 }
 
-
-#ifdef ENABLE_TEMPLATE_PROVIDER
-    #include <rusty/protocols/v2/sv2-ffi/sv2.h>
-    // It uses the sv2_ffi library to build a correct Sv2 message and an incorrect one.
-    // Then try to encode them, it print ok if the ecoding is possible it print err if not.
-    void test_template_provider()
-    {
-        EncoderWrapper * encoder = new_encoder();
-    
-        const char* error = "connection can not be created";
-        uint8_t* error_ = (uint8_t*) error;
-      
-        // Build a CSetupConnectionError message
-        CVec error_code = cvec_from_buffer(error_, strlen(error));
-        CSetupConnectionError message;
-        message.flags = 0;
-        message.error_code = error_code;
-      
-        CSv2Message response;
-        response.tag = CSv2Message::Tag::SetupConnectionError;
-        response.setup_connection_error._0 = message;
-      
-        // Put the message in a Sv2 frame and encode it
-        CResult<CVec, Sv2Error> encoded = encode(&response, encoder);
-        switch (encoded.tag) {
-      
-        // Print Ok as the message has been encoded without encoutering errors
-        case CResult < CVec, Sv2Error > ::Tag::Ok:
-          tfm::format(std::cout, "Ok \n");
-          break;
-        case CResult < CVec, Sv2Error > ::Tag::Err:
-          tfm::format(std::cout, "Err \n");
-          break;
-        };
-    
-        // Build an incorrect CSetupConnectionError message
-        CSv2Message response2;
-        response.tag = CSv2Message::Tag::SetNewPrevHash;
-        response.setup_connection_error._0 = message;
-      
-        // Put the message in a Sv2 frame and try to encode it
-        CResult<CVec, Sv2Error> encoded2 = encode(&response2, encoder);
-        switch (encoded2.tag) {
-      
-        // Print Err as is not possible to encode incorrect messages
-        case CResult < CVec, Sv2Error > ::Tag::Ok:
-          tfm::format(std::cout, "Ok \n");
-          break;
-        case CResult < CVec, Sv2Error > ::Tag::Err:
-          tfm::format(std::cout, "Err \n");
-          break;
-        };
-    };
-#endif
-
 int main(int argc, char* argv[])
 {
 #ifdef WIN32
     util::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
-#ifdef ENABLE_TEMPLATE_PROVIDER
-    test_template_provider();
-#else
 
     NodeContext node;
     int exit_status;
@@ -330,6 +272,4 @@ int main(int argc, char* argv[])
     noui_connect();
 
     return (AppInit(node, argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE);
-#endif
-
 };


### PR DESCRIPTION
TODO - Housekeeping:
* Please review from: https://github.com/stratum-mining/bitcoin/commit/9989ba6976bb9f0d97f48da8f3d4342c53be2e58
* This is currently branched from [2022.05.17-fix-template-provider-compile-options](https://github.com/stratum-mining/bitcoin/pull/21), please review and merge that PR before attempting to merge this one.
* I will rebase this PR on top of [add_sv2](https://github.com/stratum-mining/bitcoin/tree/add_sv2) if the previously mentioned PR above is merged into [add_sv2](https://github.com/stratum-mining/bitcoin/tree/add_sv2). 

This PR removes the rust ffi example code from bitcoind.cpp.